### PR TITLE
respond with proper http status codes (fixes #61)

### DIFF
--- a/src/main/scala/Router.scala
+++ b/src/main/scala/Router.scala
@@ -7,21 +7,21 @@ import util.RequestHeader
 
 final class Router(controller: Controller):
 
-  def apply(req: RequestHeader, emit: ClientEmit): Controller.Response =
+  def apply(req: RequestHeader): Controller.Response =
     req.path drop 1 split '/' match
-      case Array("socket") | Array("socket", _) => controller.site(req, emit)
-      case Array("analysis", "socket")          => controller.site(req, emit)
-      case Array("analysis", "socket", _)       => controller.site(req, emit)
-      case Array("api", "socket")               => controller.api(req, emit)
-      case Array("lobby", "socket")             => controller.lobby(req, emit)
-      case Array("lobby", "socket", _)          => controller.lobby(req, emit)
-      case Array("simul", id, "socket", _)      => controller.simul(id, req, emit)
-      case Array("tournament", id, "socket", _) => controller.tournament(id, req, emit)
-      case Array("study", id, "socket", _)      => controller.study(id, req, emit)
-      case Array("watch", id, _, _)             => controller.roundWatch(Game.Id(id), req, emit)
-      case Array("play", id, _)                 => controller.roundPlay(Game.FullId(id), req, emit)
-      case Array("challenge", id, "socket", _)  => controller.challenge(Challenge.Id(id), req, emit)
-      case Array("team", id)                    => controller.team(id, req, emit)
-      case Array("swiss", id)                   => controller.swiss(id, req, emit)
-      case Array("racer", id)                   => controller.racer(id, req, emit)
+      case Array("socket") | Array("socket", _) => controller.site(req)
+      case Array("analysis", "socket")          => controller.site(req)
+      case Array("analysis", "socket", _)       => controller.site(req)
+      case Array("api", "socket")               => controller.api(req)
+      case Array("lobby", "socket")             => controller.lobby(req)
+      case Array("lobby", "socket", _)          => controller.lobby(req)
+      case Array("simul", id, "socket", _)      => controller.simul(id, req)
+      case Array("tournament", id, "socket", _) => controller.tournament(id, req)
+      case Array("study", id, "socket", _)      => controller.study(id, req)
+      case Array("watch", id, _, _)             => controller.roundWatch(Game.Id(id), req)
+      case Array("play", id, _)                 => controller.roundPlay(Game.FullId(id), req)
+      case Array("challenge", id, "socket", _)  => controller.challenge(Challenge.Id(id), req)
+      case Array("team", id)                    => controller.team(id, req)
+      case Array("swiss", id)                   => controller.swiss(id, req)
+      case Array("racer", id)                   => controller.racer(id, req)
       case _                                    => Future successful Left(HttpResponseStatus.NOT_FOUND)

--- a/src/main/scala/netty/FrameHandler.scala
+++ b/src/main/scala/netty/FrameHandler.scala
@@ -25,8 +25,8 @@ final private class FrameHandler(using ec: ExecutionContext)
       case frame: TextWebSocketFrame =>
         val txt = frame.text
         if (txt.nonEmpty)
-          val limiter = ctx.channel.attr(key.limit).get
-          if (limiter == null || limiter(txt)) ClientOut parse txt foreach {
+          val endpoint = ctx.channel.attr(key.endpoint).get
+          if (endpoint == null || endpoint.rateLimit(txt)) ClientOut parse txt foreach {
 
             case ClientOut.Unexpected(msg) =>
               Monitor.clientOutUnexpected.increment()

--- a/src/main/scala/netty/NettyServer.scala
+++ b/src/main/scala/netty/NettyServer.scala
@@ -47,7 +47,8 @@ final class NettyServer(
             val pipeline = ch.pipeline()
             pipeline.addLast(new HttpServerCodec)
             pipeline.addLast(new HttpObjectAggregator(4096))
-            pipeline.addLast(new ProtocolHandler(clients, router))
+            pipeline.addLast(new RequestHandler(router))
+            pipeline.addLast(new ProtocolHandler(clients))
             pipeline.addLast(new FrameHandler)
           }
         })

--- a/src/main/scala/netty/ProtocolHandler.scala
+++ b/src/main/scala/netty/ProtocolHandler.scala
@@ -43,7 +43,6 @@ final private class ProtocolHandler(
   ): Unit =
     val promise = Promise[Client]()
     channel.attr(key.client).set(promise.future)
-    channel.attr(key.limit).set(endpoint.rateLimit)
     clients ! Clients.Control.Start(endpoint.behavior(emitToChannel(channel)), promise)
     channel.closeFuture.addListener(new GenericFutureListener[NettyFuture[Void]] {
       def operationComplete(f: NettyFuture[Void]): Unit =
@@ -101,4 +100,3 @@ private object ProtocolHandler:
   object key:
     val endpoint = AttributeKey.valueOf[Controller.Endpoint]("endpoint")
     val client   = AttributeKey.valueOf[Future[Client]]("client")
-    val limit    = AttributeKey.valueOf[RateLimit]("limit")

--- a/src/main/scala/netty/ProtocolHandler.scala
+++ b/src/main/scala/netty/ProtocolHandler.scala
@@ -47,11 +47,7 @@ final private class ProtocolHandler(
     clients ! Clients.Control.Start(endpoint.behavior(emitToChannel(channel)), promise)
     channel.closeFuture.addListener(new GenericFutureListener[NettyFuture[Void]] {
       def operationComplete(f: NettyFuture[Void]): Unit =
-        Option(channel.attr(key.client).get) match {
-          case Some(client) =>
-            client foreach { c => clients ! Clients.Control.Stop(c) }
-          case None => Monitor.websocketError("clientActorMissing")
-        }
+        promise.future foreach { client => clients ! Clients.Control.Stop(client) }
     })
 
   private def emitToChannel(channel: Channel): ClientEmit =

--- a/src/main/scala/netty/ProtocolHandler.scala
+++ b/src/main/scala/netty/ProtocolHandler.scala
@@ -76,13 +76,8 @@ final private class ProtocolHandler(
         ctx.close()
       // Includes normal GET requests without WebSocket upgrade
       case _: WebSocketHandshakeException =>
-        val response = new DefaultFullHttpResponse(
-          HttpVersion.HTTP_1_1,
-          HttpResponseStatus.BAD_REQUEST,
-          ctx.alloc.buffer(0)
-        )
-        val f = ctx.writeAndFlush(response)
-        f.addListener(ChannelFutureListener.CLOSE)
+        Monitor.websocketError("handshake")
+        super.exceptionCaught(ctx, cause)
       case e: CorruptedWebSocketFrameException
           if Option(e.getMessage).exists(_ startsWith "Max frame length") =>
         Monitor.websocketError("frameLength")

--- a/src/main/scala/netty/RequestHandler.scala
+++ b/src/main/scala/netty/RequestHandler.scala
@@ -14,7 +14,9 @@ import scala.concurrent.ExecutionContext
 final private class RequestHandler(
     router: Router
 )(using ec: ExecutionContext)
-    extends SimpleChannelInboundHandler[FullHttpRequest](false):
+    extends SimpleChannelInboundHandler[FullHttpRequest](
+      false // do not automatically release req
+    ):
 
   override def channelRead0(ctx: ChannelHandlerContext, req: FullHttpRequest): Unit =
     router(new util.RequestHeader(req.uri, req.headers)) foreach {

--- a/src/main/scala/netty/RequestHandler.scala
+++ b/src/main/scala/netty/RequestHandler.scala
@@ -1,6 +1,7 @@
 package lila.ws
 package netty
 
+import io.netty.buffer.Unpooled
 import io.netty.channel.{ ChannelFutureListener, ChannelHandlerContext, SimpleChannelInboundHandler }
 import io.netty.handler.codec.http.{
   DefaultFullHttpResponse,
@@ -23,14 +24,14 @@ final private class RequestHandler(
       case Left(status) =>
         sendErrorResponse(
           ctx,
-          new DefaultFullHttpResponse(req.protocolVersion(), status, ctx.alloc().buffer(0))
+          new DefaultFullHttpResponse(req.protocolVersion(), status, Unpooled.EMPTY_BUFFER)
         )
         req.release()
       case Right(_) if req.method != HttpMethod.GET =>
         val response = new DefaultFullHttpResponse(
           req.protocolVersion(),
           HttpResponseStatus.METHOD_NOT_ALLOWED,
-          ctx.alloc().buffer(0)
+          Unpooled.EMPTY_BUFFER
         )
         response.headers.set(HttpHeaderNames.ALLOW, "GET")
         sendErrorResponse(ctx, response)

--- a/src/main/scala/netty/RequestHandler.scala
+++ b/src/main/scala/netty/RequestHandler.scala
@@ -1,0 +1,44 @@
+package lila.ws
+package netty
+
+import io.netty.channel.{ ChannelFutureListener, ChannelHandlerContext, SimpleChannelInboundHandler }
+import io.netty.handler.codec.http.{
+  DefaultFullHttpResponse,
+  FullHttpRequest,
+  HttpHeaderNames,
+  HttpMethod,
+  HttpResponseStatus
+}
+import scala.concurrent.ExecutionContext
+
+final private class RequestHandler(
+    router: Router
+)(using ec: ExecutionContext)
+    extends SimpleChannelInboundHandler[FullHttpRequest](false):
+
+  override def channelRead0(ctx: ChannelHandlerContext, req: FullHttpRequest): Unit =
+    router(new util.RequestHeader(req.uri, req.headers)) foreach {
+      case Left(status) =>
+        sendErrorResponse(
+          ctx,
+          new DefaultFullHttpResponse(req.protocolVersion(), status, ctx.alloc().buffer(0))
+        )
+        req.release()
+      case Right(_) if req.method != HttpMethod.GET =>
+        val response = new DefaultFullHttpResponse(
+          req.protocolVersion(),
+          HttpResponseStatus.METHOD_NOT_ALLOWED,
+          ctx.alloc().buffer(0)
+        )
+        response.headers.set(HttpHeaderNames.ALLOW, "GET")
+        sendErrorResponse(ctx, response)
+        req.release()
+      case Right(endpoint) =>
+        // Forward to ProtocolHandler with endpoint attribute
+        ctx.channel.attr(ProtocolHandler.key.endpoint).set(endpoint)
+        ctx.fireChannelRead(req)
+    }
+
+  private def sendErrorResponse(ctx: ChannelHandlerContext, response: DefaultFullHttpResponse) =
+    val f = ctx.writeAndFlush(response)
+    f.addListener(ChannelFutureListener.CLOSE)


### PR DESCRIPTION
The recent config issue reminded me of #61.

Various code paths already return HTTP status codes that would make it easier to debug errors, but after the WebSocket upgrade it's too late to actually send an HTTP Response.

Refactor to let an intermediate `RequestHandler` handle error responses before the WebSocket `ProtocolHandler` runs.