### PR TITLE
Replace cats.implicits.* -> cats.syntax.all.*

### DIFF
--- a/src/main/scala/evalCache/EvalCacheBsonHandlers.scala
+++ b/src/main/scala/evalCache/EvalCacheBsonHandlers.scala
@@ -5,7 +5,7 @@ import reactivemongo.api.bson.*
 import reactivemongo.api.bson.exceptions.TypeDoesNotMatchException
 import scala.util.{ Failure, Success, Try }
 import cats.data.NonEmptyList
-import cats.implicits.catsSyntaxList
+import cats.syntax.all.*
 import chess.format.Uci
 
 object EvalCacheBsonHandlers:

--- a/src/main/scala/evalCache/EvalCacheJsonHandlers.scala
+++ b/src/main/scala/evalCache/EvalCacheJsonHandlers.scala
@@ -1,7 +1,7 @@
 package lila.ws
 package evalCache
 
-import cats.implicits.*
+import cats.syntax.all.*
 import chess.format.{ Fen, Uci, UciPath }
 import play.api.libs.json.*
 import chess.variant.Variant

--- a/src/main/scala/evalCache/EvalCacheSelector.scala
+++ b/src/main/scala/evalCache/EvalCacheSelector.scala
@@ -19,7 +19,7 @@ private object EvalCacheSelector:
       .sortBy(-_._1)(using intOrdering)
       // keep only the best eval in each group
       .flatMap {
-        import cats.implicits.*
+        import cats.syntax.all.*
         _._2.maximumByOption(ranking)
       }
       // now remove obsolete evals


### PR DESCRIPTION
following https://github.com/typelevel/cats/pull/4394
The consensus is to prefer cats.syntax.all.* over cats.implicits.* since cats [v2.2.0](https://github.com/typelevel/cats/releases/tag/v2.2.0).
This may help us improve compile time.