### PR TITLE
Fix IndexOutOfBoundsException when frame.content() is empty

### DIFF
--- a/src/main/scala/netty/FrameHandler.scala
+++ b/src/main/scala/netty/FrameHandler.scala
@@ -38,9 +38,10 @@ final private class FrameHandler(using Executor) extends SimpleChannelInboundHan
               case out => withClientOf(ctx.channel)(_ tell out)
 
       case frame: PongWebSocketFrame =>
-        val lagMillis = (System.currentTimeMillis() - frame.content().getLong(0)).toInt
-        val pong      = ClientOut.RoundPongFrame(lagMillis)
-        Option(ctx.channel.attr(key.client).get) foreach { _.value foreach { _ foreach (_ ! pong) } }
+        if frame.content().readableBytes() >= 8 then
+          val lagMillis = (System.currentTimeMillis() - frame.content().getLong(0)).toInt
+          val pong      = ClientOut.RoundPongFrame(lagMillis)
+          Option(ctx.channel.attr(key.client).get) foreach { _.value foreach { _ foreach (_ ! pong) } }
 
       case frame =>
         logger.info("unsupported frame type: " + frame.getClass.getName)

--- a/src/main/scala/netty/FrameHandler.scala
+++ b/src/main/scala/netty/FrameHandler.scala
@@ -41,7 +41,7 @@ final private class FrameHandler(using Executor) extends SimpleChannelInboundHan
         if frame.content().readableBytes() >= 8 then
           val lagMillis = (System.currentTimeMillis() - frame.content().getLong(0)).toInt
           val pong      = ClientOut.RoundPongFrame(lagMillis)
-          Option(ctx.channel.attr(key.client).get) foreach { _.value foreach { _ foreach (_ ! pong) } }
+          Option(ctx.channel.attr(key.client).get).foreach(_.value.foreach(_.foreach(_ ! pong)))
 
       case frame =>
         logger.info("unsupported frame type: " + frame.getClass.getName)


### PR DESCRIPTION
We have a bunch of `IndexOutOfBoundsException` warning logs.
<details>
2024-02-20 23:42:13,216 WARN  i.n.c.DefaultChannelPipeline An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception.
java.lang.IndexOutOfBoundsException: null
	at io.netty.buffer.EmptyByteBuf.getLong(EmptyByteBuf.java:317)
	at lila.ws.netty.FrameHandler.channelRead0(FrameHandler.scala:41)
	at lila.ws.netty.FrameHandler.channelRead0(FrameHandler.scala:15)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
	at io.netty.handler.codec.http.websocketx.Utf8FrameValidator.channelRead(Utf8FrameValidator.java:89)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:102)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800)
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:509)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:407)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1583)

</details>

it happen when frame.content() is empty. ByteBuf.getLong(0) will throw exception if it doesn't have enough data (aka 8 bytes).

https://github.com/netty/netty/blob/4.1/buffer/src/main/java/io/netty/buffer/ByteBuf.java#L725-L734