### PR TITLE
Fix scala deprecation warnings

### DIFF
--- a/src/main/scala/Lila.scala
+++ b/src/main/scala/Lila.scala
@@ -1,5 +1,6 @@
 package lila.ws
 
+import cats.syntax.all.*
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
 import io.lettuce.core.*
@@ -53,18 +54,20 @@ final class Lila(config: Config)(using Executor):
   )
 
   private def connectAll: Future[Emits] =
-    connect[LilaIn.Site](chans.site) zip
-      connect[LilaIn.Tour](chans.tour) zip
-      connect[LilaIn.Lobby](chans.lobby) zip
-      connect[LilaIn.Simul](chans.simul) zip
-      connect[LilaIn.Team](chans.team) zip
-      connect[LilaIn.Swiss](chans.swiss) zip
-      connect[LilaIn.Study](chans.study) zip
-      connect[LilaIn.Round](chans.round) zip
-      connect[LilaIn.Challenge](chans.challenge) zip
-      connect[LilaIn.Racer](chans.racer) map:
-        case site ~ tour ~ lobby ~ simul ~ team ~ swiss ~ study ~ round ~ challenge ~ racer =>
-          Emits(site, tour, lobby, simul, team, swiss, study, round, challenge, racer)
+    (
+      connect[LilaIn.Site](chans.site),
+      connect[LilaIn.Tour](chans.tour),
+      connect[LilaIn.Lobby](chans.lobby),
+      connect[LilaIn.Simul](chans.simul),
+      connect[LilaIn.Team](chans.team),
+      connect[LilaIn.Swiss](chans.swiss),
+      connect[LilaIn.Study](chans.study),
+      connect[LilaIn.Round](chans.round),
+      connect[LilaIn.Challenge](chans.challenge),
+      connect[LilaIn.Racer](chans.racer)
+    ).mapN:
+      case (site, tour, lobby, simul, team, swiss, study, round, challenge, racer) =>
+        Emits(site, tour, lobby, simul, team, swiss, study, round, challenge, racer)
 
   private def connect[In <: LilaIn](chan: Chan): Future[Emit[In]] =
 

--- a/src/main/scala/Lila.scala
+++ b/src/main/scala/Lila.scala
@@ -8,7 +8,6 @@ import io.lettuce.core.pubsub.*
 import ipc.*
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.concurrent.Await
-import scala.util.chaining.*
 
 final class Lila(config: Config)(using Executor):
 

--- a/src/main/scala/Lila.scala
+++ b/src/main/scala/Lila.scala
@@ -8,6 +8,7 @@ import io.lettuce.core.pubsub.*
 import ipc.*
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.concurrent.Await
+import scala.util.chaining.*
 
 final class Lila(config: Config)(using Executor):
 
@@ -65,9 +66,7 @@ final class Lila(config: Config)(using Executor):
       connect[LilaIn.Round](chans.round),
       connect[LilaIn.Challenge](chans.challenge),
       connect[LilaIn.Racer](chans.racer)
-    ).mapN:
-      case (site, tour, lobby, simul, team, swiss, study, round, challenge, racer) =>
-        Emits(site, tour, lobby, simul, team, swiss, study, round, challenge, racer)
+    ).mapN(Emits.apply(_, _, _, _, _, _, _, _, _, _))
 
   private def connect[In <: LilaIn](chan: Chan): Future[Emit[In]] =
 

--- a/src/main/scala/SocialGraph.scala
+++ b/src/main/scala/SocialGraph.scala
@@ -3,8 +3,7 @@ package lila.ws
 import com.typesafe.config.Config
 import java.util.concurrent.locks.ReentrantLock
 import scala.jdk.CollectionConverters.*
-import scala.util.boundary
-import scala.util.Random
+import scala.util.{ boundary, Random }
 
 // Best effort fixed capacity cache for the social graph of online users.
 //
@@ -61,9 +60,9 @@ final class SocialGraph(mongo: Mongo, config: Config):
     for s <- hash to (hash + SocialGraph.MaxStride) do
       val slot = s & slotsMask
       read(slot) match
-        case None => boundary.break[Slot](NewSlot(slot))
+        case None => boundary.break(NewSlot(slot))
         case Some(existing) if existing.id == id =>
-          boundary.break[Slot](ExistingSlot(slot, existing))
+          boundary.break(ExistingSlot(slot, existing))
         case _ =>
 
     // If no existing or empty slot is available, try to replace an
@@ -75,11 +74,11 @@ final class SocialGraph(mongo: Mongo, config: Config):
     for s <- hash to (hash + SocialGraph.MaxStride) do
       val slot = s & slotsMask
       read(slot) match
-        case None => boundary.break[Slot](NewSlot(slot))
+        case None => boundary.break(NewSlot(slot))
         case Some(existing) if existing.id == id =>
-          boundary.break[Slot](ExistingSlot(slot, existing))
+          boundary.break(ExistingSlot(slot, existing))
         case Some(existing) if !existing.meta.online && slot != exceptSlot =>
-          boundary.break[Slot](freeSlot(slot))
+          boundary.break(freeSlot(slot))
         case _ =>
 
     // The hashtable is full. Overwrite a random entry.

--- a/src/main/scala/SocialGraph.scala
+++ b/src/main/scala/SocialGraph.scala
@@ -3,7 +3,7 @@ package lila.ws
 import com.typesafe.config.Config
 import java.util.concurrent.locks.ReentrantLock
 import scala.jdk.CollectionConverters.*
-import scala.util.control.NonLocalReturns.*
+import scala.util.boundary
 import scala.util.Random
 
 // Best effort fixed capacity cache for the social graph of online users.
@@ -54,16 +54,16 @@ final class SocialGraph(mongo: Mongo, config: Config):
       (Integer.rotateLeft(state, 5) ^ ch.toInt) * 0x9e3779b9
     }
 
-  private def findSlot(id: User.Id, exceptSlot: Int): Slot = returning[Slot]:
+  private def findSlot(id: User.Id, exceptSlot: Int): Slot = boundary[Slot]:
     // Try to find an existing or empty slot between hash and
     // hash + MaxStride.
     val hash = fxhash32(id) & slotsMask
     for s <- hash to (hash + SocialGraph.MaxStride) do
       val slot = s & slotsMask
       read(slot) match
-        case None => throwReturn[Slot](NewSlot(slot))
+        case None => boundary.break[Slot](NewSlot(slot))
         case Some(existing) if existing.id == id =>
-          throwReturn[Slot](ExistingSlot(slot, existing))
+          boundary.break[Slot](ExistingSlot(slot, existing))
         case _ =>
 
     // If no existing or empty slot is available, try to replace an
@@ -75,11 +75,11 @@ final class SocialGraph(mongo: Mongo, config: Config):
     for s <- hash to (hash + SocialGraph.MaxStride) do
       val slot = s & slotsMask
       read(slot) match
-        case None => throwReturn[Slot](NewSlot(slot))
+        case None => boundary.break[Slot](NewSlot(slot))
         case Some(existing) if existing.id == id =>
-          throwReturn[Slot](ExistingSlot(slot, existing))
+          boundary.break[Slot](ExistingSlot(slot, existing))
         case Some(existing) if !existing.meta.online && slot != exceptSlot =>
-          throwReturn[Slot](freeSlot(slot))
+          boundary.break[Slot](freeSlot(slot))
         case _ =>
 
     // The hashtable is full. Overwrite a random entry.

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -18,7 +18,7 @@ type Client         = ActorRef[ipc.ClientMsg]
 type ClientEmit     = Emit[ipc.ClientIn]
 
 type ~[+A, +B] = Tuple2[A, B]
-object ~ :
+object `~`:
   def apply[A, B](x: A, y: B)                              = Tuple2(x, y)
   def unapply[A, B](x: Tuple2[A, B]): Option[Tuple2[A, B]] = Some(x)
 

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -17,10 +17,5 @@ type ClientBehavior = Behavior[ipc.ClientMsg]
 type Client         = ActorRef[ipc.ClientMsg]
 type ClientEmit     = Emit[ipc.ClientIn]
 
-type ~[+A, +B] = Tuple2[A, B]
-object `~`:
-  def apply[A, B](x: A, y: B)                              = Tuple2(x, y)
-  def unapply[A, B](x: Tuple2[A, B]): Option[Tuple2[A, B]] = Some(x)
-
 def nowSeconds: Int = (System.currentTimeMillis() / 1000).toInt
 val startedAtMillis = System.currentTimeMillis()


### PR DESCRIPTION
> object NonLocalReturns in package scala.util.control is deprecated since 3.3: Use scala.util.boundary instead

> method returning in object NonLocalReturns is deprecated since 3.3: Use scala.util.boundary instead

> method throwReturn in object NonLocalReturns is deprecated since 3.3: Use scala.util.boundary.break instead
  
> `:` after symbolic operator is deprecated; use backticks around operator instead