### PR TITLE
Allow users to appear anonymously while spectating games

### DIFF
--- a/src/main/scala/Controller.scala
+++ b/src/main/scala/Controller.scala
@@ -105,7 +105,10 @@ final class Controller(
 
   def roundWatch(id: Game.Id, header: RequestHeader) =
     WebSocket(header): req =>
-      mongo.gameExists(id) zip mongo.troll.is(req.user) zip mongo.isAppearAnon(req.user) zip roundFrom(id into Game.AnyId, req) map:
+      mongo.gameExists(id) zip mongo.troll.is(req.user) zip mongo.isAppearAnon(req.user) zip roundFrom(
+        id into Game.AnyId,
+        req
+      ) map:
         case (((true, isTroll), appearAnon), from) =>
           val userTv = UserTv.from(header queryParameter "userTv")
           endpoint(

--- a/src/main/scala/Controller.scala
+++ b/src/main/scala/Controller.scala
@@ -105,14 +105,14 @@ final class Controller(
 
   def roundWatch(id: Game.Id, header: RequestHeader) =
     WebSocket(header): req =>
-      mongo.gameExists(id) zip mongo.troll.is(req.user) zip roundFrom(id into Game.AnyId, req) map:
-        case ((true, isTroll), from) =>
+      mongo.gameExists(id) zip mongo.troll.is(req.user) zip mongo.isAppearAnon(req.user) zip roundFrom(id into Game.AnyId, req) map:
+        case (((true, isTroll), appearAnon), from) =>
           val userTv = UserTv.from(header queryParameter "userTv")
           endpoint(
             name = "round/watch",
             behavior = emit =>
               RoundClientActor
-                .start(RoomActor.State(id.into(RoomId), isTroll), None, userTv, from):
+                .start(RoomActor.State(id.into(RoomId), isTroll), None, userTv, from, appearAnon):
                   Deps(emit, req, services)
             ,
             header,

--- a/src/main/scala/Mongo.scala
+++ b/src/main/scala/Mongo.scala
@@ -59,6 +59,7 @@ final class Mongo(config: Config)(using Executor) extends MongoHandlers:
   def oauthColl                                     = collNamed("oauth2_access_token")
   def relayTourColl                                 = collNamed("relay_tour")
   def relayRoundColl                                = collNamed("relay")
+  def prefColl                                      = collNamed("pref")
   def studyColl                                     = studyDb.map(_ collection "study")(parasitic)
   def evalCacheColl                                 = yoloDb.map(_ collection "eval_cache")(parasitic)
 
@@ -75,6 +76,10 @@ final class Mongo(config: Config)(using Executor) extends MongoHandlers:
 
   private def isTeamMember(teamId: Team.Id, user: User.Id): Future[Boolean] =
     teamMemberColl flatMap { exists(_, BSONDocument("_id" -> s"${user.value}@$teamId")) }
+
+  def isAppearAnon(user: Option[User.Id]): Future[Boolean] =
+    user.fold(Future successful false)(u => prefColl flatMap:
+      exists(_, BSONDocument("_id" -> u, "appearAnon" -> true)))
 
   def teamView(id: Team.Id, me: Option[User.Id]): Future[Option[Team.HasChat]] =
     teamColl

--- a/src/main/scala/Mongo.scala
+++ b/src/main/scala/Mongo.scala
@@ -78,8 +78,10 @@ final class Mongo(config: Config)(using Executor) extends MongoHandlers:
     teamMemberColl flatMap { exists(_, BSONDocument("_id" -> s"${user.value}@$teamId")) }
 
   def isAppearAnon(user: Option[User.Id]): Future[Boolean] =
-    user.fold(Future successful false)(u => prefColl flatMap:
-      exists(_, BSONDocument("_id" -> u, "appearAnon" -> true)))
+    user.fold(Future successful false)(u =>
+      prefColl flatMap:
+        exists(_, BSONDocument("_id" -> u, "appearAnon" -> true))
+    )
 
   def teamView(id: Team.Id, me: Option[User.Id]): Future[Option[Team.HasChat]] =
     teamColl

--- a/src/main/scala/RoomCrowd.scala
+++ b/src/main/scala/RoomCrowd.scala
@@ -71,9 +71,7 @@ object RoomCrowd:
       anons = room.anons + room.users.count(_._2.appearAnon)
     )
 
-  case class UserStatus(
-      connected: Int,
-      appearAnon: Boolean)
+  case class UserStatus(connected: Int, appearAnon: Boolean)
   case class RoomState(
       anons: Int = 0,
       users: Map[User.Id, UserStatus] = Map.empty
@@ -83,12 +81,20 @@ object RoomCrowd:
     def isEmpty   = nbMembers < 1
 
     def connect(user: Option[User.Id]): RoomState =
-      connect(user,false)
+      connect(user, false)
     def connectAnon(user: Option[User.Id]): RoomState =
-      connect(user,true)
+      connect(user, true)
     private def connect(user: Option[User.Id], appearAnon: Boolean): RoomState =
       user.fold(copy(anons = anons + 1)): u =>
-        copy(users = users.updatedWith(u)(cur => Some(cur.fold(UserStatus(1,appearAnon))(s => UserStatus(s.connected + 1,s.appearAnon)))))
+        copy(users =
+          users.updatedWith(u)(cur =>
+            Some(cur.fold(UserStatus(1, appearAnon))(s => UserStatus(s.connected + 1, s.appearAnon)))
+          )
+        )
     def disconnect(user: Option[User.Id]): RoomState =
       user.fold(copy(anons = anons - 1)): u =>
-        copy(users = users.updatedWith(u)(m => m.map(cur => UserStatus(cur.connected - 1, cur.appearAnon)).filter(_.connected > 0)))
+        copy(users =
+          users.updatedWith(u)(m =>
+            m.map(cur => UserStatus(cur.connected - 1, cur.appearAnon)).filter(_.connected > 0)
+          )
+        )

--- a/src/main/scala/RoomCrowd.scala
+++ b/src/main/scala/RoomCrowd.scala
@@ -82,13 +82,13 @@ object RoomCrowd:
     def nbMembers = anons + nbUsers
     def isEmpty   = nbMembers < 1
 
-    def connect(user: Option[User.Id]) =
-      doConnect(user,false)
-    def connectAnon(user: Option[User.Id]) =
-      doConnect(user,true)
-    private def doConnect(user: Option[User.Id], appearAnon: Boolean) =
+    def connect(user: Option[User.Id]): RoomState =
+      connect(user,false)
+    def connectAnon(user: Option[User.Id]): RoomState =
+      connect(user,true)
+    private def connect(user: Option[User.Id], appearAnon: Boolean): RoomState =
       user.fold(copy(anons = anons + 1)): u =>
         copy(users = users.updatedWith(u)(cur => Some(cur.fold(UserStatus(1,appearAnon))(s => UserStatus(s.connected + 1,s.appearAnon)))))
-    def disconnect(user: Option[User.Id]) =
+    def disconnect(user: Option[User.Id]): RoomState =
       user.fold(copy(anons = anons - 1)): u =>
         copy(users = users.updatedWith(u)(m => m.map(cur => UserStatus(cur.connected - 1, cur.appearAnon)).filter(_.connected > 0)))

--- a/src/main/scala/RoundCrowd.scala
+++ b/src/main/scala/RoundCrowd.scala
@@ -18,7 +18,10 @@ final class RoundCrowd(
   def connect(roomId: RoomId, user: Option[User.Id], player: Option[Color], appearAnon: Boolean): Unit =
     publish(
       roomId,
-      rounds.compute(roomId, (_, cur) => Option(cur).getOrElse(RoundState()).connect(user, player, appearAnon))
+      rounds.compute(
+        roomId,
+        (_, cur) => Option(cur).getOrElse(RoundState()).connect(user, player, appearAnon)
+      )
     )
 
   def disconnect(roomId: RoomId, user: Option[User.Id], player: Option[Color]): Unit =
@@ -78,7 +81,8 @@ object RoundCrowd:
   ):
     def connect(user: Option[User.Id], player: Option[Color], appearAnon: Boolean = false) =
       copy(
-        room = if player.isDefined then room else if appearAnon then room connectAnon user else room connect user,
+        room =
+          if player.isDefined then room else if appearAnon then room connectAnon user else room connect user,
         players = player.fold(players)(c => players.update(c, _ + 1))
       )
     def disconnect(user: Option[User.Id], player: Option[Color]) =

--- a/src/main/scala/RoundCrowd.scala
+++ b/src/main/scala/RoundCrowd.scala
@@ -15,10 +15,10 @@ final class RoundCrowd(
 
   private val rounds = ConcurrentHashMap[RoomId, RoundState](32768)
 
-  def connect(roomId: RoomId, user: Option[User.Id], player: Option[Color]): Unit =
+  def connect(roomId: RoomId, user: Option[User.Id], player: Option[Color], appearAnon: Boolean): Unit =
     publish(
       roomId,
-      rounds.compute(roomId, (_, cur) => Option(cur).getOrElse(RoundState()).connect(user, player))
+      rounds.compute(roomId, (_, cur) => Option(cur).getOrElse(RoundState()).connect(user, player, appearAnon))
     )
 
   def disconnect(roomId: RoomId, user: Option[User.Id], player: Option[Color]): Unit =
@@ -76,9 +76,9 @@ object RoundCrowd:
       room: RoomCrowd.RoomState = RoomCrowd.RoomState(),
       players: ByColor[Int] = ByColor(0, 0)
   ):
-    def connect(user: Option[User.Id], player: Option[Color]) =
+    def connect(user: Option[User.Id], player: Option[Color], appearAnon: Boolean = false) =
       copy(
-        room = if player.isDefined then room else room connect user,
+        room = if player.isDefined then room else if appearAnon then room connectAnon user else room connect user,
         players = player.fold(players)(c => players.update(c, _ + 1))
       )
     def disconnect(user: Option[User.Id], player: Option[Color]) =

--- a/src/main/scala/actor/RoundClientActor.scala
+++ b/src/main/scala/actor/RoundClientActor.scala
@@ -35,7 +35,7 @@ object RoundClientActor:
       player: Option[Game.RoundPlayer],
       userTv: Option[UserTv],
       from: Either[Option[SocketVersion], JsonString],
-      appearAnon: Boolean = false,
+      appearAnon: Boolean = false
   )(deps: Deps): Behavior[ClientMsg] =
     Behaviors.setup: ctx =>
       import deps.*

--- a/src/main/scala/actor/RoundClientActor.scala
+++ b/src/main/scala/actor/RoundClientActor.scala
@@ -34,7 +34,8 @@ object RoundClientActor:
       roomState: RoomActor.State,
       player: Option[Game.RoundPlayer],
       userTv: Option[UserTv],
-      from: Either[Option[SocketVersion], JsonString]
+      from: Either[Option[SocketVersion], JsonString],
+      appearAnon: Boolean = false,
   )(deps: Deps): Behavior[ClientMsg] =
     Behaviors.setup: ctx =>
       import deps.*
@@ -42,7 +43,7 @@ object RoundClientActor:
       onStart(deps, ctx)
       req.user foreach { users.connect(_, ctx.self) }
       state.busChans foreach { Bus.subscribe(_, ctx.self) }
-      roundCrowd.connect(roomState.room, req.user, player.map(_.color))
+      roundCrowd.connect(roomState.room, req.user, player.map(_.color), appearAnon)
       from match
         case Left(version) =>
           History.round.getFrom(roomState.room.into(Game.Id), version) match


### PR DESCRIPTION
Loads the value created in https://github.com/lichess-org/lila/pull/14775 from MongoDB and modifies the table of spectators to store whether that user appears anonymously or not.

Then, when reporting the room status, will add users appearing anonymously to the anon count and remove them from the list of users specified.

User spectating a game anonymously using this setting:

![image](https://github.com/lichess-org/lila-ws/assets/4148906/946826fb-f7b1-43f0-b1bc-fbe27e840d8d)

The only thing I was not sure about was whether or not to look up the user's preference in MongoDB or have it be sent as part of the call to the websocket. I chose to do the lookup here to decouple the logic more but I can see the extra db call being something we would want to avoid. Another option would be to not care about the user's preference all all while connecting but to handle it when the room's status is requested, but I felt that would lead to an extremely large number of db calls.