### PR TITLE
Improve frameLag calculation to handle spikes and faster recovery

### DIFF
--- a/src/main/scala/Lag.scala
+++ b/src/main/scala/Lag.scala
@@ -1,6 +1,6 @@
 package lila.ws
 
-import com.github.blemale.scaffeine.{ Cache, Scaffeine }
+import com.github.blemale.scaffeine.{Cache, Scaffeine}
 import lila.ws.ipc.LilaIn
 import lila.ws.util.Domain
 
@@ -17,8 +17,9 @@ final class Lag(lilaRedis: Lila, groupedWithin: util.GroupedWithin):
 
   export trustedStats.getIfPresent as sessionLag
 
-  private val clientReports = groupedWithin[(User.Id, Int)](256, 947.millis) { lags =>
-    lilaRedis.emit.site(LilaIn.Lags(lags.toMap))
+  private val clientReports = groupedWithin[(User.Id, Int)](256, 947.millis) {
+    lags =>
+      lilaRedis.emit.site(LilaIn.Lags(lags.toMap))
   }
 
   export clientReports.apply as recordClientLag
@@ -29,7 +30,9 @@ final class Lag(lilaRedis: Lila, groupedWithin: util.GroupedWithin):
       trustedStats.put(
         uid,
         sessionLag(uid).fold(millis) { prev =>
-          val weight = if (millis < prev) trustedNormalRefreshFactor else trustedSpikeRefreshFactor
+          val weight =
+            if (millis < prev) trustedNormalRefreshFactor
+            else trustedSpikeRefreshFactor
           val cappedMillis = millis.min(maxMillis)
           (prev * (1 - weight) + cappedMillis * weight).toInt
         }

--- a/src/main/scala/Lag.scala
+++ b/src/main/scala/Lag.scala
@@ -1,36 +1,32 @@
 package lila.ws
 
 import com.github.blemale.scaffeine.{ Cache, Scaffeine }
+
 import lila.ws.ipc.LilaIn
 import lila.ws.util.Domain
 
 final class Lag(lilaRedis: Lila, groupedWithin: util.GroupedWithin):
-  private type TrustedMillis = Int
-  private val trustedSpikeRefreshFactor = 0.05f
-  private val trustedNormalRefreshFactor = 0.1f
-  private val maxMillis = 5000
 
-  private val trustedStats: Cache[User.Id, TrustedMillis] =
-    Scaffeine().expireAfterWrite(1.hour).build[User.Id, TrustedMillis]()
+  private type TrustedMillis = Int
+  private val trustedRefreshFactor = 0.1f
+
+  private val trustedStats: Cache[User.Id, TrustedMillis] = Scaffeine()
+    .expireAfterWrite(1 hour)
+    .build[User.Id, TrustedMillis]()
 
   export trustedStats.getIfPresent as sessionLag
 
-  private val clientReports = groupedWithin[(User.Id, Int)](256, 947.millis) { lags =>
+  private val clientReports = groupedWithin[(User.Id, Int)](256, 947.millis): lags =>
     lilaRedis.emit.site(LilaIn.Lags(lags.toMap))
-  }
 
   export clientReports.apply as recordClientLag
 
   def recordTrustedLag(millis: Int, userId: Option[User.Id], domain: Domain) =
     Monitor.lag.roundFrameLag(millis, domain)
-    userId.foreach { uid =>
+    userId.foreach: uid =>
       trustedStats.put(
         uid,
-        sessionLag(uid).fold(millis) { prev =>
-          val weight =
-            if millis < prev then trustedNormalRefreshFactor else trustedSpikeRefreshFactor
-          val cappedMillis = millis.min(maxMillis)
-          (prev * (1 - weight) + cappedMillis * weight).toInt
-        }
+        sessionLag(uid)
+          .fold(millis): prev =>
+            (prev * (1 - trustedRefreshFactor) + millis * trustedRefreshFactor).toInt
       )
-    }

--- a/src/main/scala/Lag.scala
+++ b/src/main/scala/Lag.scala
@@ -1,25 +1,22 @@
 package lila.ws
 
-import com.github.blemale.scaffeine.{Cache, Scaffeine}
+import com.github.blemale.scaffeine.{ Cache, Scaffeine }
 import lila.ws.ipc.LilaIn
 import lila.ws.util.Domain
 
 final class Lag(lilaRedis: Lila, groupedWithin: util.GroupedWithin):
-
   private type TrustedMillis = Int
   private val trustedSpikeRefreshFactor = 0.05f
   private val trustedNormalRefreshFactor = 0.1f
   private val maxMillis = 5000
 
-  private val trustedStats: Cache[User.Id, TrustedMillis] = Scaffeine()
-    .expireAfterWrite(1.hour)
-    .build[User.Id, TrustedMillis]()
+  private val trustedStats: Cache[User.Id, TrustedMillis] =
+    Scaffeine().expireAfterWrite(1.hour).build[User.Id, TrustedMillis]()
 
   export trustedStats.getIfPresent as sessionLag
 
-  private val clientReports = groupedWithin[(User.Id, Int)](256, 947.millis) {
-    lags =>
-      lilaRedis.emit.site(LilaIn.Lags(lags.toMap))
+  private val clientReports = groupedWithin[(User.Id, Int)](256, 947.millis) { lags =>
+    lilaRedis.emit.site(LilaIn.Lags(lags.toMap))
   }
 
   export clientReports.apply as recordClientLag
@@ -31,8 +28,7 @@ final class Lag(lilaRedis: Lila, groupedWithin: util.GroupedWithin):
         uid,
         sessionLag(uid).fold(millis) { prev =>
           val weight =
-            if (millis < prev) trustedNormalRefreshFactor
-            else trustedSpikeRefreshFactor
+            if millis < prev then trustedNormalRefreshFactor else trustedSpikeRefreshFactor
           val cappedMillis = millis.min(maxMillis)
           (prev * (1 - weight) + cappedMillis * weight).toInt
         }

--- a/src/main/scala/Lag.scala
+++ b/src/main/scala/Lag.scala
@@ -16,7 +16,7 @@ final class Lag(lilaRedis: Lila, groupedWithin: util.GroupedWithin):
 
   export trustedStats.getIfPresent as sessionLag
 
-  private val clientReports = groupedWithin[(User.Id, Int)](256, 947.millis) { lags =>
+  private val clientReports = groupedWithin[(User.Id, Int)](256, 947.millis): lags =>
     lilaRedis.emit.site(LilaIn.Lags(lags.toMap))
   }
 
@@ -24,7 +24,7 @@ final class Lag(lilaRedis: Lila, groupedWithin: util.GroupedWithin):
 
   def recordTrustedLag(millis: Int, userId: Option[User.Id], domain: Domain) =
     Monitor.lag.roundFrameLag(millis, domain)
-    userId.foreach { uid =>
+    userId.foreach: uid =>
       trustedStats.put(
         uid,
         sessionLag(uid).fold(millis) { prev =>

--- a/src/main/scala/Lag.scala
+++ b/src/main/scala/Lag.scala
@@ -6,27 +6,32 @@ import lila.ws.ipc.LilaIn
 import lila.ws.util.Domain
 
 final class Lag(lilaRedis: Lila, groupedWithin: util.GroupedWithin):
-
   private type TrustedMillis = Int
-  private val trustedRefreshFactor = 0.1f
+  private val trustedSpikeRefreshFactor  = 0.05f
+  private val trustedNormalRefreshFactor = 0.1f
+  private val maxMillis                  = 5000
 
-  private val trustedStats: Cache[User.Id, TrustedMillis] = Scaffeine()
-    .expireAfterWrite(1 hour)
-    .build[User.Id, TrustedMillis]()
+  private val trustedStats: Cache[User.Id, TrustedMillis] =
+    Scaffeine().expireAfterWrite(1.hour).build[User.Id, TrustedMillis]()
 
   export trustedStats.getIfPresent as sessionLag
 
-  private val clientReports = groupedWithin[(User.Id, Int)](256, 947.millis): lags =>
+  private val clientReports = groupedWithin[(User.Id, Int)](256, 947.millis) { lags =>
     lilaRedis.emit.site(LilaIn.Lags(lags.toMap))
+  }
 
   export clientReports.apply as recordClientLag
 
   def recordTrustedLag(millis: Int, userId: Option[User.Id], domain: Domain) =
     Monitor.lag.roundFrameLag(millis, domain)
-    userId.foreach: uid =>
+    userId.foreach { uid =>
       trustedStats.put(
         uid,
-        sessionLag(uid)
-          .fold(millis): prev =>
-            (prev * (1 - trustedRefreshFactor) + millis * trustedRefreshFactor).toInt
+        sessionLag(uid).fold(millis) { prev =>
+          val weight =
+            if millis < prev then trustedNormalRefreshFactor else trustedSpikeRefreshFactor
+          val cappedMillis = millis.min(maxMillis)
+          (prev * (1 - weight) + cappedMillis * weight).toInt
+        }
       )
+    }

--- a/src/main/scala/Lag.scala
+++ b/src/main/scala/Lag.scala
@@ -8,7 +8,9 @@ import lila.ws.util.Domain
 final class Lag(lilaRedis: Lila, groupedWithin: util.GroupedWithin):
 
   private type TrustedMillis = Int
-  private val trustedRefreshFactor = 0.1f
+  private val trustedSpikeRefreshFactor = 0.05f
+  private val trustedNormalRefreshFactor = 0.1f
+  private val maxMillis = 5000
 
   private val trustedStats: Cache[User.Id, TrustedMillis] = Scaffeine()
     .expireAfterWrite(1 hour)
@@ -28,5 +30,7 @@ final class Lag(lilaRedis: Lila, groupedWithin: util.GroupedWithin):
         uid,
         sessionLag(uid)
           .fold(millis): prev =>
-            (prev * (1 - trustedRefreshFactor) + millis * trustedRefreshFactor).toInt
+            val weight = if (millis < prev) trustedNormalRefreshFactor else trustedSpikeRefreshFactor
+            val cappedMillis = millis.min(maxMillis)
+            (prev * (1 - weight) + cappedMillis * weight).toInt
       )

--- a/src/main/scala/Lag.scala
+++ b/src/main/scala/Lag.scala
@@ -1,7 +1,6 @@
 package lila.ws
 
 import com.github.blemale.scaffeine.{ Cache, Scaffeine }
-
 import lila.ws.ipc.LilaIn
 import lila.ws.util.Domain
 
@@ -13,24 +12,26 @@ final class Lag(lilaRedis: Lila, groupedWithin: util.GroupedWithin):
   private val maxMillis = 5000
 
   private val trustedStats: Cache[User.Id, TrustedMillis] = Scaffeine()
-    .expireAfterWrite(1 hour)
+    .expireAfterWrite(1.hour)
     .build[User.Id, TrustedMillis]()
 
   export trustedStats.getIfPresent as sessionLag
 
-  private val clientReports = groupedWithin[(User.Id, Int)](256, 947.millis): lags =>
+  private val clientReports = groupedWithin[(User.Id, Int)](256, 947.millis) { lags =>
     lilaRedis.emit.site(LilaIn.Lags(lags.toMap))
+  }
 
   export clientReports.apply as recordClientLag
 
   def recordTrustedLag(millis: Int, userId: Option[User.Id], domain: Domain) =
     Monitor.lag.roundFrameLag(millis, domain)
-    userId.foreach: uid =>
+    userId.foreach { uid =>
       trustedStats.put(
         uid,
-        sessionLag(uid)
-          .fold(millis): prev =>
-            val weight = if (millis < prev) trustedNormalRefreshFactor else trustedSpikeRefreshFactor
-            val cappedMillis = millis.min(maxMillis)
-            (prev * (1 - weight) + cappedMillis * weight).toInt
+        sessionLag(uid).fold(millis) { prev =>
+          val weight = if (millis < prev) trustedNormalRefreshFactor else trustedSpikeRefreshFactor
+          val cappedMillis = millis.min(maxMillis)
+          (prev * (1 - weight) + cappedMillis * weight).toInt
+        }
       )
+    }


### PR DESCRIPTION
Implemented ideas as mentioned in #395 where massive spikes can cause the weighted average to skyrocket and take a long time to recover. The changes introduce separate refresh factors for spike and normal values, cap the maximum recorded value, and adjust the calculation to allow faster recovery when recording lower values.