### PR TITLE
prevent devious scheduling from reporting negative size to kamon

### DIFF
--- a/src/main/scala/netty/ActorChannelConnector.scala
+++ b/src/main/scala/netty/ActorChannelConnector.scala
@@ -97,8 +97,8 @@ object ActorChannelConnector:
     private val size  = java.util.concurrent.atomic.AtomicInteger()
 
     def add(channel: Channel): Unit =
-      queue.add(channel)
       size.getAndIncrement()
+      queue.add(channel)
 
     def poll(): Option[Channel] =
       val maybeChannel = Option(queue.poll())


### PR DESCRIPTION
ConcurrentLinkedQueue.add is not atomic with respect to AtomicInteger.getAndIncrement. I think we should increment the size variable *before* we call `add` to address this race condition:

Thread A is executing the `flush()` loop.
Thread B calls `flushQ.add`, the channel is added, but the thread is interrupted before incrementing `size`.
Thread A empties the queue and now `flushQ.size` is actually `-1`.
Thread A takes a 1ms nap while thread B remains suspended.
Thread A wakes up and enters flush() again, assigning `flushQ.estimateSize()` (which is still `-1`) to `qSize`
Thread B finally resumes and corrects the `size` variable, but the spurious negative value has already been captured and will be reported to kamon.

A negative could spike the y-axis scale if grafana or another process in the reporting chain is configured to expect unsigned values.