### PR TITLE
remove qSizeReal monitoring

### DIFF
--- a/src/main/scala/Monitor.scala
+++ b/src/main/scala/Monitor.scala
@@ -188,7 +188,6 @@ object Monitor:
         val step     = Kamon.gauge("connector.flush.config.step").withoutTags()
         val interval = Kamon.gauge("connector.flush.config.interval").withoutTags()
         val maxDelay = Kamon.gauge("connector.flush.config.maxDelay").withoutTags()
-      val qSizeReal               = Kamon.histogram("connector.flush.qSize").withoutTags()
       val qSizeEstimate           = Kamon.histogram("connector.flush.qSize.estimate").withoutTags()
       val channelsToFlush         = Kamon.histogram("connector.flush.channelsToFlush").withoutTags()
       val loopRuntimeMicroseconds = Kamon.histogram("connector.flush.loopRuntimeMicroseconds").withoutTags()

--- a/src/main/scala/netty/ActorChannelConnector.scala
+++ b/src/main/scala/netty/ActorChannelConnector.scala
@@ -36,7 +36,6 @@ final private class ActorChannelConnector(
       monitor.config.step.update(step.get())
       monitor.config.interval.update(interval.get())
       monitor.config.maxDelay.update(maxDelay.get())
-      monitor.qSizeReal.record(flushQ.realSizeWithLinearPerformance())
 
   def apply(endpoint: Endpoint, channel: Channel): Unit =
     val clientPromise = Promise[Client]()
@@ -105,5 +104,4 @@ object ActorChannelConnector:
       if maybeChannel.nonEmpty then size.getAndDecrement()
       maybeChannel
 
-    def estimateSize(): Int                  = size.get()
-    def realSizeWithLinearPerformance(): Int = queue.size()
+    def estimateSize(): Int = size.get()


### PR DESCRIPTION
real and estimate do not drift away from each other (https://monitor.lichess.ovh/d/RdXOn3JWk/lila-ws?orgId=1&from=2024-12-18T03:28:59.364Z&to=2024-12-18T22:56:08.038Z&timezone=utc&var-host=starr&var-field=mean&viewPanel=panel-66), so i don't think we need this anymore.

real is just more spiky, because it can see emptied and full queues and everything inbetween, whereas estimates are always recorded after a flush iteration.