### PR TITLE
Remove compat for lichess mobile: don't send study messages in batches

### DIFF
--- a/src/main/scala/actor/RoomActor.scala
+++ b/src/main/scala/actor/RoomActor.scala
@@ -47,15 +47,10 @@ object RoomActor:
       None -> None
 
     case ClientIn.VersionedBatch(msgs) =>
-      if deps.req.isLichessMobile // BC, remove this in a month
-      then
-        msgs.toList.reverse.foreach: msg =>
-          deps.clientIn(versionFor(state.isTroll, msg))
-      else
-        deps.clientIn:
-          ClientIn.PayloadBatch:
-            msgs.toList.reverse.map: msg =>
-              versionFor(state.isTroll, msg).json
+      deps.clientIn:
+        ClientIn.PayloadBatch:
+          msgs.toList.reverse.map: msg =>
+            versionFor(state.isTroll, msg).json
       None -> None
 
     case ClientIn.OnlyFor(endpoint, payload) =>


### PR DESCRIPTION
Batch support for the lichess mobile app was added [here](https://github.com/lichess-org/mobile/pull/1328).

It should only be merged before the next big broadcast event to let time to users to upgrade the app as it will break older versions.