### PR TITLE
Don't generate docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,8 @@ lazy val `lila-ws` = project
     Docker / dockerRepository := Some("ghcr.io"),
     Universal / javaOptions := Seq(
       "-J-Dconfig.override_with_env_vars=true"
-    )
+    ),
+    Compile / doc / sources := Seq.empty
   )
 
 addCommandAlias("prepare", "scalafixAll; scalafmtAll")


### PR DESCRIPTION
fixes "[error] (Compile / doc) DottyDoc Compilation Failed" with scala 3.6.3