### PR TITLE
hide stream info from lila-ws behind json

### DIFF
--- a/src/main/scala/LilaHandler.scala
+++ b/src/main/scala/LilaHandler.scala
@@ -4,6 +4,7 @@ import cats.data.NonEmptyList
 import com.typesafe.scalalogging.Logger
 import org.apache.pekko.actor.typed.{ ActorRef, Scheduler }
 import scalalib.ThreadLocalRandom
+import play.api.libs.json.JsValue
 
 import lila.ws.util.Batcher
 
@@ -53,9 +54,9 @@ final class LilaHandler(
       )
     case ApiUserOnline(user, false) => users.tellOne(user, ClientCtrl.ApiDisconnect)
 
-    case Impersonate(user, by)                                   => Impersonations(user, by)
-    case StreamersOnline(streamers: Iterable[(User.Id, String)]) => Streamer.set(streamers)
-    case Pong(pingAt)                                            => Monitor.ping.record("site", pingAt)
+    case Impersonate(user, by)                                    => Impersonations(user, by)
+    case StreamersOnline(streamers: Iterable[(User.Id, JsValue)]) => Streamer.set(streamers)
+    case Pong(pingAt)                                             => Monitor.ping.record("site", pingAt)
 
     case LilaStop(reqId) =>
       logger.info("******************** LILA STOP ********************")

--- a/src/main/scala/Streamer.scala
+++ b/src/main/scala/Streamer.scala
@@ -1,11 +1,13 @@
 package lila.ws
 
+import play.api.libs.json.JsValue
+
 // this set comes from lila/modules/streamer and is updated a few times per minute at most
 object Streamer:
-  @volatile private var streams = Map.empty[User.Id, String]
+  @volatile private var streams = Map.empty[User.Id, JsValue]
 
-  def set(newStreams: Iterable[(User.Id, String)]): Unit =
+  def set(newStreams: Iterable[(User.Id, JsValue)]): Unit =
     streams = newStreams.toMap
 
-  def intersect(userIds: Iterable[User.Id]): Map[User.Id, String] =
+  def intersect(userIds: Iterable[User.Id]): Map[User.Id, JsValue] =
     streams.view.filterKeys(userIds.toSet).toMap


### PR DESCRIPTION
- make stream info json
- some unavoidable parsing at the message level to get userId for set intersections
- use JsArray rather than commas() (which was previously broken anyways if a streamer had a comma in their name)

# Must be deployed in tandem with the corresponding lila commit