### PR TITLE
verify that cloud eval lines are unique

### DIFF
--- a/src/main/scala/evalCache/EvalCacheEntry.scala
+++ b/src/main/scala/evalCache/EvalCacheEntry.scala
@@ -67,10 +67,10 @@ object EvalCacheEntry:
 
     def bestMove: Uci = bestPv.moves.value.head
 
-    def looksValid =
-      pvs.toList.forall(_.looksValid) && (
-        pvs.toList.forall(_.score.mateFound) || (knodes >= MIN_KNODES || depth >= MIN_DEPTH)
-      )
+    def looksValid = pvs.forall(_.looksValid) && uniqueFirstMoves &&
+      pvs.forall(_.score.mateFound) || (knodes >= MIN_KNODES || depth >= MIN_DEPTH)
+
+    private def uniqueFirstMoves = pvs.map(_.moves.value.head.uci).distinct.size == pvs.size
 
     def truncatePvs = copy(pvs = pvs.map(_.truncate))
 


### PR DESCRIPTION
Closes https://github.com/lichess-org/lila/issues/17632, https://github.com/lichess-org/lila/issues/16561

I assume what is happening is some race condition in the client where analysis shifts in the local object while posting to the server. Anyways, better to check at the server.