### PR TITLE
Update reactivemongo 1.1.0-RC13 -> RC16

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val `lila-ws` = project
     resolvers += "jitpack".at("https://jitpack.io"),
     resolvers += "lila-maven".at("https://raw.githubusercontent.com/ornicar/lila-maven/master"),
     libraryDependencies ++= Seq(
-      ("org.reactivemongo" %% "reactivemongo" % "1.1.0-RC13")
+      ("org.reactivemongo" %% "reactivemongo" % "1.1.0-RC16")
         .exclude("org.scala-lang.modules", "scala-java8-compat_2.13"),
       "org.reactivemongo" % s"reactivemongo-shaded-native-$os-$arch" % "1.1.0-RC16",
       "io.lettuce" % "lettuce-core" % "6.8.0.RELEASE",


### PR DESCRIPTION
Fixes startup problem I see in lila-docker lila_ws service,
```
...
ClassNotFoundException: reactivemongo.io.netty.channel.IoHandle
...
```

Relates: a4686e2e0