### PR TITLE
Revert "Support docker arm64"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,8 +43,5 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Build and push Docker image
         run: sbt Docker/publish

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,10 @@ inThisBuild(
     scalaVersion := "3.7.2",
     versionScheme := Some("early-semver"),
     version := "3.3",
-    semanticdbEnabled := true, // for scalafix
     dockerBaseImage := "openjdk:21",
     dockerUpdateLatest := true,
-    dockerBuildxPlatforms := Seq("linux/amd64", "linux/arm64")
+    semanticdbEnabled := true, // for scalafix
+    dockerBaseImage := "openjdk:21"
   )
 )
 


### PR DESCRIPTION
This reverts commit 3989fc4e0354cdeecb28062564bb7c408badd84c.

As it turned out, building lila-ws for mac complicated every things. It better just build it for linux.

In order to remove `WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested` warning, we can add this for example in docker compose file:
`platform: linux/amd64`