### PR TITLE
Add setClock to study message type

### DIFF
--- a/src/main/scala/ipc/ClientOut.scala
+++ b/src/main/scala/ipc/ClientOut.scala
@@ -182,7 +182,7 @@ object ClientOut:
                   "leave" | "shapes" | "addChapter" | "setChapter" | "editChapter" | "descStudy" |
                   "descChapter" | "deleteChapter" | "clearAnnotations" | "sortChapters" | "editStudy" |
                   "setTag" | "setComment" | "deleteComment" | "setGamebook" | "toggleGlyph" | "explorerGame" |
-                  "requestAnalysis" | "invite" | "relaySync" | "setTopics" | "clearVariations" =>
+                  "requestAnalysis" | "invite" | "relaySync" | "setTopics" | "clearVariations" | "setClock" =>
                 Some(StudyForward(o))
               // round
               case "move" =>


### PR DESCRIPTION
Study clock editing in the lila UI sends a `setClock` message over the websocket. This adds `setClock` to the study message type in `ClientOut` so the server forwards it to the study handler.

## Related
- **Lila:** This change supports study chapter clock editing in the main repo. PR: https://github.com/lichess-org/lila/pull/19728