### PR TITLE
Evalcache mate sanity

### DIFF
--- a/src/main/scala/evalCache/EvalCacheApi.scala
+++ b/src/main/scala/evalCache/EvalCacheApi.scala
@@ -2,7 +2,6 @@ package lila.ws
 package evalCache
 
 import cats.syntax.all.*
-import chess.ErrorStr
 import chess.format.Fen
 import com.github.blemale.scaffeine.AsyncLoadingCache
 import com.softwaremill.macwire.*
@@ -103,7 +102,7 @@ final class EvalCacheApi(mongo: Mongo)(using Executor, Scheduler)(using cacheApi
 
   private def putTrusted(user: User.Id, input: Input): Future[Unit] =
     mongo.evalCacheColl.flatMap: c =>
-      validate(input).match
+      input.validate.match
         case Left(error) =>
           Logger("EvalCacheApi.put").info(s"Invalid from ${user} $error ${input.fen}")
           Future.successful(())
@@ -136,6 +135,3 @@ final class EvalCacheApi(mongo: Mongo)(using Executor, Scheduler)(using cacheApi
     // todo: debounce upgrades in hot rooms
     upgrade.onEval(input)
     multi.onEval(input)
-
-  private def validate(in: EvalCacheEntry.Input): Either[ErrorStr, Unit] =
-    in.eval.pvs.traverse_(pv => in.position.validate(pv.moves.value))

--- a/src/main/scala/evalCache/EvalCacheEntry.scala
+++ b/src/main/scala/evalCache/EvalCacheEntry.scala
@@ -7,6 +7,7 @@ import chess.eval.Score
 import chess.format.{ BinaryFen, Fen, Uci }
 import chess.variant.Variant
 import com.github.blemale.scaffeine.{ LoadingCache, Scaffeine }
+import scalalib.zeros.given
 
 import java.time.LocalDateTime
 
@@ -90,12 +91,12 @@ object EvalCacheEntry:
     def truncate = copy(moves = Moves.truncate(moves))
 
   def makeInput(variant: Variant, fen: Fen.Full, eval: Eval, sri: Sri) =
-    Fen
-      .read(variant, fen)
-      .filter(_.playable(false))
-      .ifTrue(eval.looksValid)
-      .map: position =>
-        Input(Id(position), fen, position, eval.truncatePvs, sri)
+    eval.looksValid.so:
+      Fen
+        .read(variant, fen)
+        .filter(_.playable(false))
+        .map: position =>
+          Input(Id(position), fen, position, eval.truncatePvs, sri)
 
   // val fen = "r1bqkb1r/ppp2ppp/2n2n2/3pp1N1/2B1P3/8/PPPP1PPP/RNBQK2R w KQkq - 0 5"
   // println("FEN ID: " + evalCache.EvalCacheEntry.showMongoIdForDebug(fen))

--- a/src/main/scala/evalCache/EvalCacheEntry.scala
+++ b/src/main/scala/evalCache/EvalCacheEntry.scala
@@ -95,12 +95,11 @@ object EvalCacheEntry:
       case Some(mate) => mate.value != 0 // sometimes we get #0. Dunno why.
 
     def isValidMate(lastPos: Position) =
-      score.mate
-        .forall: mate =>
-          val plies = moves.value.size
-          val mateInPlies = mate.value.abs * 2
-          if plies == mateInPlies || plies == mateInPlies - 1 then lastPos.checkMate
-          else plies < mateInPlies && mateInPlies > MAX_PV_SIZE
+      score.mate.forall: mate =>
+        val plies = moves.value.size
+        val mateInPlies = mate.value.abs * 2
+        if plies == mateInPlies || plies == mateInPlies - 1 then lastPos.checkMate
+        else plies < mateInPlies && mateInPlies > MAX_PV_SIZE
 
     def truncate = copy(moves = Moves.truncate(moves))
 

--- a/src/main/scala/evalCache/EvalCacheEntry.scala
+++ b/src/main/scala/evalCache/EvalCacheEntry.scala
@@ -2,10 +2,11 @@ package lila.ws
 package evalCache
 
 import cats.data.NonEmptyList
-import chess.Position
+import cats.implicits.toFoldableOps
 import chess.eval.Score
 import chess.format.{ BinaryFen, Fen, Uci }
 import chess.variant.Variant
+import chess.{ ErrorStr, Position }
 import com.github.blemale.scaffeine.{ LoadingCache, Scaffeine }
 import scalalib.zeros.given
 
@@ -58,7 +59,12 @@ case class EvalCacheEntry(
 
 object EvalCacheEntry:
 
-  case class Input(id: Id, fen: Fen.Full, position: Position, eval: Eval, sri: Sri)
+  case class Input(id: Id, fen: Fen.Full, position: Position, eval: Eval, sri: Sri):
+    def validate: Either[ErrorStr, Unit] =
+      eval.pvs.traverse_ : pv =>
+        position
+          .forward(pv.moves.value)
+          .filterOrElse(pv.isValidMate(_), chess.ErrorStr(s"Invalid mate $pv"))
 
   case class Eval(pvs: NonEmptyList[Pv], knodes: Knodes, depth: Depth, by: User.Id, trust: Trust):
 
@@ -87,6 +93,14 @@ object EvalCacheEntry:
     def looksValid = score.mate match
       case None => moves.value.toList.sizeIs > MIN_PV_SIZE
       case Some(mate) => mate.value != 0 // sometimes we get #0. Dunno why.
+
+    def isValidMate(lastPos: Position) =
+      score.mate
+        .forall: mate =>
+          val plies = moves.value.size
+          val mateInPlies = mate.value.abs * 2
+          if plies == mateInPlies || plies == mateInPlies - 1 then lastPos.checkMate
+          else plies < mateInPlies && mateInPlies > MAX_PV_SIZE
 
     def truncate = copy(moves = Moves.truncate(moves))
 

--- a/src/test/scala/EvalCacheTest.scala
+++ b/src/test/scala/EvalCacheTest.scala
@@ -3,23 +3,78 @@ package evalCache
 
 import cats.data.NonEmptyList
 import chess.eval.Score
-import chess.format.Uci
+import chess.format.{ Fen, Uci }
 
 import EvalCacheEntry.*
 
 class EvalCacheTest extends munit.FunSuite:
 
-  test("Multiple repeated lines should be invalid"):
-    val moves = Moves.from(Uci.Move("e2e4").map(NonEmptyList.one)).get
-    val eval = Eval(
-      pvs = NonEmptyList
-        .one(Pv(Score.cp(40), moves))
-        .concat(
-          List(Pv(Score.cp(50), moves))
-        ),
+  private def makeEval(score: Score, moves: String) =
+    Eval(
+      pvs = NonEmptyList.one:
+        Pv(
+          score,
+          Moves:
+            NonEmptyList.fromListUnsafe:
+              moves
+                .split(" ")
+                .toList
+                .map(Uci.Move.apply)
+                .flatten
+        )
+      ,
       knodes = MIN_KNODES,
       depth = Depth(25),
       by = User.Id("user"),
       trust = Trust(1)
     )
+
+  private def makeInput(
+      eval: Eval,
+      fen: String = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+      variant: chess.variant.Variant = chess.variant.Standard
+  ) =
+    EvalCacheEntry.makeInput(
+      variant = variant,
+      fen = Fen.Full(fen),
+      eval = eval,
+      sri = Sri("sri")
+    )
+
+  test("Multiple repeated lines should be invalid"):
+    val pv1 = makeEval(Score.cp(50), "e2e4")
+    val eval = pv1.copy(pvs = pv1.pvs.append(pv1.pvs.head.copy(score = Score.cp(40))))
     assertEquals(eval.looksValid, false)
+
+  test("Mate eval should be invalid if we reach the last position and it's not mate"):
+    val moves = "e2e4"
+    val eval = makeEval(Score.mate(1), moves)
+    val input = makeInput(eval)
+    assertEquals(
+      input.map(_.validate),
+      Some(Left(chess.ErrorStr("Invalid mate Pv(Mate(1),NonEmptyList(Move(e2e4)))")))
+    )
+
+  test("PV cannot be longer than mate eval"):
+    val line = "e2e4 e7e5 d2d4"
+    val eval = makeEval(Score.mate(1), line)
+    val input = makeInput(eval)
+    assertEquals(
+      input.map(_.validate),
+      Some(
+        Left(chess.ErrorStr("Invalid mate Pv(Mate(1),NonEmptyList(Move(e2e4), Move(e7e5), Move(d2d4)))"))
+      )
+    )
+
+  test("Really long mate evals with pvs truncated should be valid"):
+    val antichess_forced = "b7b5 f1b5 d7d5 b5e8 d5e4 e8f7 d8d2 c1d2 h7h5 f7h5"
+    val eval = makeEval(Score.mate(-16), antichess_forced)
+    val input =
+      makeInput(eval, "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b - - 0 1", chess.variant.Antichess)
+    assertEquals(input.map(_.validate), Some(Right(())))
+
+  test("Valid mate in 2"):
+    val moves = "c4f7 e8e7 c3d5"
+    val eval = makeEval(Score.mate(2), moves)
+    val input = makeInput(eval, "r2qkbnr/ppp2ppp/2np4/4N3/2B1P3/2N5/PPPP1PPP/R1BbK2R w KQkq - 0 6")
+    assertEquals(input.map(_.validate), Some(Right(())))


### PR DESCRIPTION
To avoid situations like https://github.com/lichess-org/lila/issues/20919

If we have
```scala
Pv(score: Mate(1), moves: Nel("e2e4"))
```

1. If the length of moves == mate then check if the last position is indeed checkmate. We were already playing out the moves to make sure the moves themselves were valid.
2. If the length of moves < mate then there are two scenarios:
i. The mate is really distant (#-16) and we don't include enough moves in the Pv to check if the end position is indeed checkmate. Allow it.
ii. The client didn't supply enough moves to reach checkmate. e.g. Only send the first move out of a 3 move sequence. Reject it.
3. Mate in 1 is sent along with a 4 move sequence. Reject it.

Add tests for all cases