### PR TITLE
Use reactivemongo pekko-noshaded flavor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,13 @@ inThisBuild(
 )
 
 Universal / target := baseDirectory.value / "target" / "universal"
-val os = if (sys.props.get("os.name").exists(_.startsWith("Mac"))) "osx" else "linux"
-val arch = if (sys.props.get("os.arch").exists(_.startsWith("aarch64"))) "aarch-64" else "x86-64"
-val arch_ = arch.replace("-", "_")
+
+def nettyTransport =
+  val arch = if (sys.props.get("os.arch").exists(_.startsWith("aarch64"))) "aarch_64" else "x86_64"
+  val (os, notifier) =
+  if System.getProperty("os.name").toLowerCase.startsWith("mac") then ("osx", "kqueue")
+  else ("linux", "epoll")
+  ("io.netty" % s"netty-transport-native-$notifier" % nettyVersion).classifier(s"$os-$arch")
 
 val pekkoVersion = "1.6.0"
 val kamonVersion = "2.8.1"
@@ -33,10 +37,7 @@ lazy val `lila-ws` = project
       "io.lettuce" % "lettuce-core" % "7.6.0.RELEASE",
       "io.netty" % "netty-handler" % nettyVersion,
       "io.netty" % "netty-codec-http" % nettyVersion,
-      ("io.netty" % s"netty-transport-native-epoll" % nettyVersion)
-        .classifier(s"linux-$arch_"),
-      ("io.netty" % s"netty-transport-native-kqueue" % nettyVersion)
-        .classifier(s"osx-$arch_"),
+      nettyTransport,
       "com.github.lichess-org.scalalib" %% "scalalib-lila" % "11.10.11",
       "com.github.lichess-org.scalachess" %% "scalachess" % chessVersion,
       "com.github.lichess-org.scalachess" %% "scalachess-play-json" % chessVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -28,9 +28,7 @@ lazy val `lila-ws` = project
     resolvers += "jitpack".at("https://jitpack.io"),
     resolvers += "lila-maven".at("https://raw.githubusercontent.com/ornicar/lila-maven/master"),
     libraryDependencies ++= Seq(
-      ("org.reactivemongo" %% "reactivemongo" % "1.1.0-RC20")
-        .exclude("org.scala-lang.modules", "scala-java8-compat_2.13"),
-      "org.reactivemongo" % s"reactivemongo-shaded-native-$os-$arch" % "1.1.0-RC20",
+      "org.reactivemongo" %% "reactivemongo" % "1.1.0-pekko.noshaded.RC21",
       "io.lettuce" % "lettuce-core" % "7.6.0.RELEASE",
       "io.netty" % "netty-handler" % nettyVersion,
       "io.netty" % "netty-codec-http" % nettyVersion,

--- a/src/main/scala/netty/NettyServer.scala
+++ b/src/main/scala/netty/NettyServer.scala
@@ -4,8 +4,6 @@ package netty
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.Logger
 import io.netty.bootstrap.ServerBootstrap
-import io.netty.channel.epoll.{ EpollEventLoopGroup, EpollServerSocketChannel }
-import io.netty.channel.kqueue.{ KQueueEventLoopGroup, KQueueServerSocketChannel }
 import io.netty.channel.{ Channel, ChannelInitializer }
 import io.netty.handler.codec.http.*
 
@@ -17,10 +15,9 @@ final class NettyServer(
 )(using Executor, Scheduler):
   private val logger = Logger(getClass)
   private val threads = config.getInt("netty.threads")
-  private val (parent, workers, channelClass) =
-    if System.getProperty("os.name").toLowerCase.startsWith("mac") then
-      (new KQueueEventLoopGroup(1), new KQueueEventLoopGroup(threads), classOf[KQueueServerSocketChannel])
-    else (new EpollEventLoopGroup(1), new EpollEventLoopGroup(threads), classOf[EpollServerSocketChannel])
+  private val pack = Pack.instance
+  private val parent = pack.eventLoopGroupFactory(1)
+  private val workers = pack.eventLoopGroupFactory(threads)
   private val connector = ActorChannelConnector(clients, config, settings, workers)
 
   def start(): Unit =
@@ -32,7 +29,7 @@ final class NettyServer(
       val boot = new ServerBootstrap
       boot
         .group(parent, workers)
-        .channel(channelClass)
+        .channel(pack.channelClass)
         .childHandler(
           new ChannelInitializer[Channel]:
             override def initChannel(ch: Channel): Unit =

--- a/src/main/scala/netty/Pack.scala
+++ b/src/main/scala/netty/Pack.scala
@@ -1,0 +1,54 @@
+package lila.ws
+package netty
+
+import io.netty.channel.ServerChannel
+import io.netty.channel.EventLoopGroup
+import scala.util.control.NonFatal
+
+// Adapted from https://github.com/ReactiveMongo/ReactiveMongo/blob/5560470ee409da827feee161c16631042e194263/driver/src/main/scala/core/netty/Pack.scala#L15
+private final class Pack(
+    val eventLoopGroupFactory: Int => EventLoopGroup,
+    val channelClass: Class[? <: ServerChannel]
+)
+
+private object Pack:
+  private val kqueuePkg: String = "io.netty.channel.kqueue"
+  private val epollPkg: String = "io.netty.channel.epoll"
+
+  def instance: Pack =
+    epoll.orElse(kqueue).getOrElse { throw RuntimeException("Can't initialize either Netty Epoll or Kqueue") }
+
+  private def epoll: Option[Pack] =
+    try
+      Some(Class.forName(s"${epollPkg}.EpollServerSocketChannel")).map { cls =>
+        val chanClass = cls.asInstanceOf[Class[? <: ServerChannel]]
+        val groupClass = Class
+          .forName(s"${epollPkg}.EpollEventLoopGroup")
+          .asInstanceOf[Class[? <: EventLoopGroup]]
+
+        val groupCtor = groupClass.getDeclaredConstructor(classOf[Int])
+        new Pack(
+          nThreads => groupCtor.newInstance(Int.box(nThreads)),
+          chanClass
+        )
+      }
+    catch
+      case NonFatal(cause) =>
+        None
+
+  private def kqueue: Option[Pack] =
+    try
+      Some(Class.forName(s"${kqueuePkg}.KQueueServerSocketChannel")).map { cls =>
+        val chanClass = cls.asInstanceOf[Class[? <: ServerChannel]]
+        val groupClass = Class
+          .forName(s"${kqueuePkg}.KQueueEventLoopGroup")
+          .asInstanceOf[Class[? <: EventLoopGroup]]
+        val groupCtor = groupClass.getDeclaredConstructor(classOf[Int])
+        new Pack(
+          nThreads => groupCtor.newInstance(Int.box(nThreads)),
+          chanClass
+        )
+      }
+    catch
+      case NonFatal(cause) =>
+        None

--- a/src/main/scala/netty/Pack.scala
+++ b/src/main/scala/netty/Pack.scala
@@ -1,8 +1,8 @@
 package lila.ws
 package netty
 
-import io.netty.channel.ServerChannel
-import io.netty.channel.EventLoopGroup
+import io.netty.channel.{ EventLoopGroup, ServerChannel }
+
 import scala.util.control.NonFatal
 
 // Adapted from https://github.com/ReactiveMongo/ReactiveMongo/blob/5560470ee409da827feee161c16631042e194263/driver/src/main/scala/core/netty/Pack.scala#L15
@@ -33,7 +33,7 @@ private object Pack:
         )
       }
     catch
-      case NonFatal(cause) =>
+      case NonFatal(_) =>
         None
 
   private def kqueue: Option[Pack] =
@@ -50,5 +50,5 @@ private object Pack:
         )
       }
     catch
-      case NonFatal(cause) =>
+      case NonFatal(_) =>
         None


### PR DESCRIPTION
This changes reactivemongo setup similar to lila which:
- Move completely to pekko from akka as the default actor system for
  reactivemongo is akka.
- Use non shaded version of netty which is safe because both reactivemongo
and lila-ws uses netty 4.2.
- Bump reactivemongo to RC21 again

Fix #900 